### PR TITLE
0.15.1

### DIFF
--- a/recipe/abs.yaml
+++ b/recipe/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+    psteyer: transformers-test

--- a/recipe/abs.yaml
+++ b/recipe/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-    psteyer: transformers-test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,8 +29,6 @@ requirements:
     - python
     - pip
     - setuptools-rust
-    - setuptools
-    - wheel
     - openssl {{ openssl }} # [linux]
     - maturin
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tokenizers" %}
-{% set version = "0.13.3" %}
+{% set version = "0.15.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 2e546dbb68b623008a5442353137fbb0123d311a6d7ba52f2667c8862a75af2e
+  sha256: c0a331d6d5a3d6e97b7f99f562cee8d56797180797bc55f12070e495e717c980
 
 build:
   number: 0
@@ -32,9 +32,11 @@ requirements:
     - setuptools
     - wheel
     - openssl {{ openssl }} # [linux]
+    - maturin
   run:
     - python
     - openssl # [linux]
+    - huggingface_hub
 
 test:
   imports:
@@ -47,6 +49,7 @@ test:
     - tokenizers.trainers
     - tokenizers.implementations
     - tokenizers.tools
+    - huggingface_hub
   commands:
     - pip check
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
   run:
     - python
     - openssl # [linux]
-    - huggingface_hub
+    - huggingface_hub >=0.16.4,<1.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<35 or win32 or (win64 and (rust_compiler == 'rust-gnu'))]
+  skip: True  # [py<37]
   missing_dso_whitelist:
     - /usr/lib/libresolv.9.dylib  # [osx]
     - /usr/lib64/libgcc_s.so.1  # [linux]
@@ -28,7 +28,6 @@ requirements:
   host:
     - python
     - pip
-    - setuptools-rust
     - openssl {{ openssl }} # [linux]
     - maturin >=1.0,<2.0
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - pip
     - setuptools-rust
     - openssl {{ openssl }} # [linux]
-    - maturin
+    - maturin >=1.0,<2.0
   run:
     - python
     - openssl # [linux]


### PR DESCRIPTION
Minor version update from `0.13.3` -> `0.15.1`

Dependency update for `transformers` to resolve CVE-2023-7018 and CVE-2023-6730.

jira: https://anaconda.atlassian.net/browse/PKG-3827

[`tokenizers`](https://github.com/AnacondaRecipes/tokenizers-feedstock/pull/9) -> [`transformers`](https://github.com/AnacondaRecipes/transformers-feedstock/pull/10)

### Changes:
- updated version number
- updated sha
- added build dependency `maturin`
- added run dependency `huggingface_hub`
- added test imports dependency `huggingface_hub`
- removed `win32`
- updated skip to `py<37`