### PR TITLE
tokenizers 0.20.1

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,2 @@
 rust_compiler_version:
-  - 1.64.0
+  - 1.76.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,8 +57,7 @@ test:
     - pip check
     - cd bindings/python
     # tests require multiprocessing with fork, which is not available on Windows.
-    - pytest tests --ignore="tests/documentation" -k "not test_continuing_prefix_trainer_mistmatch"  # [not win]
-    - pytest tests --ignore="tests/documentation" -k "not (test_continuing_prefix_trainer_mistmatch or test_multiprocessing_with_parallelism)" # [win]
+    - pytest tests --ignore="tests/documentation" -k "not test_continuing_prefix_trainer_mistmatch"
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tokenizers" %}
-{% set version = "0.19.1" %}
+{% set version = "0.20.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ee59e6680ed0fdbe6b724cf38bd70400a0c1dd623b07ac729087270caeac88e3
+  sha256: 84edcc7cdeeee45ceedb65d518fffb77aec69311c9c8e30f77ad84da3025f002
   patches:  # [win]
     - remove-multiprocess-fork.patch  # [win]
 
@@ -16,8 +16,8 @@ build:
   skip: True  # [py<37]
   missing_dso_whitelist:
     - /usr/lib/libresolv.9.dylib  # [osx]
-    - /usr/lib64/libgcc_s.so.1  # [linux]
-    - $RPATH/ld64.so.1  # [s390x]
+    - /usr/lib64/libgcc_s.so.1    # [linux]
+    - $RPATH/ld64.so.1            # [s390x]
   script:
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
@@ -31,11 +31,11 @@ requirements:
   host:
     - python
     - pip
-    - openssl {{ openssl }} # [linux]
+    - openssl {{ openssl }}  # [linux]
     - maturin >=1.0,<2.0
   run:
     - python
-    - openssl # [linux]
+    - openssl  # [linux]
     - huggingface_hub >=0.16.4,<1.0
 
 test:
@@ -65,7 +65,6 @@ test:
     - requests
     - numpy
     - datasets
-    - ruff
 
 about:
   home: https://github.com/huggingface/tokenizers

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,8 @@ test:
     - pip check
     - cd bindings/python
     # tests require multiprocessing with fork, which is not available on Windows.
-    - pytest tests --ignore="tests/documentation" -k "not test_continuing_prefix_trainer_mistmatch"
+    - pytest tests --ignore="tests/documentation" -k "not test_continuing_prefix_trainer_mistmatch"  # [not win]
+    - pytest tests --ignore="tests/documentation" -k "not (test_continuing_prefix_trainer_mistmatch or test_multiprocessing_with_parallelism)" # [win]
   requires:
     - pip
     - pytest

--- a/recipe/remove-multiprocess-fork.patch
+++ b/recipe/remove-multiprocess-fork.patch
@@ -1,16 +1,3 @@
-diff --git a/bindings/python/tests/bindings/test_tokenizer.py b/bindings/python/tests/bindings/test_tokenizer.py
-index 3d04960..95895a4 100644
---- a/bindings/python/tests/bindings/test_tokenizer.py
-+++ b/bindings/python/tests/bindings/test_tokenizer.py
-@@ -9,7 +9,7 @@ from tokenizers.models import BPE, Model, Unigram
- from tokenizers.pre_tokenizers import ByteLevel
- from tokenizers.processors import RobertaProcessing
- 
--from ..utils import bert_files, data_dir, multiprocessing_with_parallelism, roberta_files
-+from ..utils import bert_files, data_dir, roberta_files
- 
- 
- class TestAddedToken:
 diff --git a/bindings/python/tests/utils.py b/bindings/python/tests/utils.py
 index 0d497e6..6f44421 100644
 --- a/bindings/python/tests/utils.py


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira]() 
- [Upstream repository](https://github.com/huggingface/tokenizers/tree/v0.20.1)
- Requirements: https://github.com/huggingface/tokenizers/blob/v0.20.1/bindings/python/pyproject.toml

### Explanation of changes:

- Bump the rust compiler version
- Clean up the recipe and improve indentations.
- Remove `ruff` from `test/requires` as it's not needed for tests.

### Notes:

- `transformers 4.45.2` requires `tokenizers >=0.20,<0.21`