### PR TITLE
v0.20.1 rebuild with rust 1.82

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,2 @@
 rust_compiler_version:
-  - 1.76.0
+  - 1.82.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - remove-multiprocess-fork.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<37]
   missing_dso_whitelist:
     - /usr/lib/libresolv.9.dylib  # [osx]


### PR DESCRIPTION
tokenizers v0.20.1 rebuild

**Destination channel:** defaults

### Links

- [PKG-6194](https://anaconda.atlassian.net/browse/PKG-6194) 

### Explanation of changes:

- Bump build number and build with rust 1.82

Rust < 1.81 was affected by CVE-2024-43402.  


[PKG-6194]: https://anaconda.atlassian.net/browse/PKG-6194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ