### PR TITLE
v0.21.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/datasets-feedstock/pr5/bbc3bba

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
-
-channels:
-  - https://staging.continuum.io/prefect/fs/datasets-feedstock/pr5/bbc3bba

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tokenizers" %}
-{% set version = "0.20.1" %}
+{% set version = "0.21.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 84edcc7cdeeee45ceedb65d518fffb77aec69311c9c8e30f77ad84da3025f002
+  sha256: ee0894bf311b75b0c03079f33859ae4b2334d675d4e93f5a4132e1eae2834fe4
   patches:  # [win]
     - remove-multiprocess-fork.patch  # [win]
 
 build:
-  number: 1
+  number: 0
   skip: True  # [py<37]
   missing_dso_whitelist:
     - /usr/lib/libresolv.9.dylib  # [osx]


### PR DESCRIPTION
tokenizers v0.21.0

**Destination channel:** defaults

### Links

- [PKG-7145](https://anaconda.atlassian.net/browse/PKG-7145) 
- [Upstream repository](https://github.com/huggingface/tokenizers/tree/v0.21.0)
- [pyproject.toml](https://github.com/huggingface/tokenizers/blob/v0.21.0/bindings/python/pyproject.toml)

### Explanation of changes:

- Bump version and SHA
- Build for python 3.13
- Reset build number. 


[PKG-7145]: https://anaconda.atlassian.net/browse/PKG-7145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ