### PR TITLE
tokenizers 0.22.1 

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,0 @@
-rust_compiler_version:
-  - 1.82.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,11 +23,11 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('rust') }}
     # It's needed to find openssl
     - pkg-config
-    - m2-patch  # [win]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37]
+  skip: True  # [py<39]
   missing_dso_whitelist:
     - /usr/lib/libresolv.9.dylib  # [osx]
     - /usr/lib64/libgcc_s.so.1    # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tokenizers" %}
-{% set version = "0.21.0" %}
+{% set version = "0.22.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ee0894bf311b75b0c03079f33859ae4b2334d675d4e93f5a4132e1eae2834fe4
+  sha256: 61de6522785310a309b3407bac22d99c4db5dba349935e99e4d15ea2226af2d9
   patches:  # [win]
     - remove-multiprocess-fork.patch  # [win]
 
@@ -65,6 +65,7 @@ test:
     - requests
     - numpy
     - datasets
+    - pytest-asyncio
 
 about:
   home: https://github.com/huggingface/tokenizers


### PR DESCRIPTION
tokenizers 0.22.1 

**Destination channel:** Defaults

### Links

- [PKG-10422]
- dev_url:        https://github.com/huggingface/tokenizers/tree/v0.22.1
- conda_forge:    https://github.com/conda-forge/tokenizers-feedstock
- pypi:           https://pypi.org/project/tokenizers/0.22.1
- pypi inspector: https://inspector.pypi.io/project/tokenizers/0.22.1

### Explanation of changes:

- new version number
- aligned with current standards
- fixed tests
- used most recent rust compiler


[PKG-10422]: https://anaconda.atlassian.net/browse/PKG-10422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ