### PR TITLE
tokenizers 0.22.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,7 @@
+# Could not solve for environment specs
+# The following packages are incompatible
+# ├─ gxx_linux-64 =14.3.0 * is requested and can be installed;
+# └─ rust_linux-64 =1.89.0 * is not installable because it requires
+#    └─ gxx_linux-64 =11.2.0 *, which conflicts with any installable versions previously reported.
+cxx_compiler_version:      # [linux]
+  - 11.2.0                 # [linux]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,5 +3,5 @@
 # ├─ gxx_linux-64 =14.3.0 * is requested and can be installed;
 # └─ rust_linux-64 =1.89.0 * is not installable because it requires
 #    └─ gxx_linux-64 =11.2.0 *, which conflicts with any installable versions previously reported.
-cxx_compiler_version:
-  - 11.2.0
+cxx_compiler_version:  # [linux]
+  - 11.2.0             # [linux]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,5 +3,5 @@
 # ├─ gxx_linux-64 =14.3.0 * is requested and can be installed;
 # └─ rust_linux-64 =1.89.0 * is not installable because it requires
 #    └─ gxx_linux-64 =11.2.0 *, which conflicts with any installable versions previously reported.
-cxx_compiler_version:      # [linux]
-  - 11.2.0                 # [linux]
+cxx_compiler_version:
+  - 11.2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,18 +6,18 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 61de6522785310a309b3407bac22d99c4db5dba349935e99e4d15ea2226af2d9
   patches:  # [win]
     - remove-multiprocess-fork.patch  # [win]
 
 build:
-  number: 0
-  skip: True  # [py<39]
+  number: 1
+  skip: true  # [py<39]
   missing_dso_whitelist:
     - /usr/lib/libresolv.9.dylib  # [osx]
-    - /usr/lib64/libgcc_s.so.1    # [linux]
-    - $RPATH/ld64.so.1            # [s390x]
+    - /usr/lib64/libgcc_s.so.1  # [linux]
+    - $RPATH/ld64.so.1  # [s390x]
   script:
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
@@ -58,7 +58,7 @@ test:
     - cd bindings/python
     # tests require multiprocessing with fork, which is not available on Windows.
     - pytest tests --ignore="tests/documentation" -k "not test_continuing_prefix_trainer_mistmatch"  # [not win]
-    - pytest tests --ignore="tests/documentation" -k "not (test_continuing_prefix_trainer_mistmatch or test_multiprocessing_with_parallelism)" # [win]
+    - pytest tests --ignore="tests/documentation" -k "not (test_continuing_prefix_trainer_mistmatch or test_multiprocessing_with_parallelism)"  # [win]
   requires:
     - pip
     - pytest
@@ -74,7 +74,7 @@ about:
   license_file: LICENSE
   summary: Fast State-of-the-Art Tokenizers optimized for Research and Production
   description: |
-    Provides an implementation of today's most used tokenizers, with a focus on 
+    Provides an implementation of today's most used tokenizers, with a focus on
     performance and versatility.
   dev_url: https://github.com/huggingface/tokenizers
   doc_url: https://huggingface.co/docs/tokenizers/index

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tokenizers" %}
-{% set version = "0.22.1" %}
+{% set version = "0.22.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 61de6522785310a309b3407bac22d99c4db5dba349935e99e4d15ea2226af2d9
+  sha256: ea401ee4db62dfd59c29d9d8c117d03263eb41a6d52b33d129b8d0d15c2c68cb
   patches:  # [win]
     - remove-multiprocess-fork.patch  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,6 @@ build:
   missing_dso_whitelist:
     - /usr/lib/libresolv.9.dylib  # [osx]
     - /usr/lib64/libgcc_s.so.1  # [linux]
-    - $RPATH/ld64.so.1  # [s390x]
   script:
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,13 +6,14 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  # v0.22.2 is not released on PyPI yet
+  url: https://github.com/huggingface/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: ea401ee4db62dfd59c29d9d8c117d03263eb41a6d52b33d129b8d0d15c2c68cb
   patches:  # [win]
     - remove-multiprocess-fork.patch  # [win]
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<39]
   missing_dso_whitelist:
     - /usr/lib/libresolv.9.dylib  # [osx]
@@ -63,7 +64,7 @@ test:
     - pytest
     - requests
     - numpy
-    - datasets
+    - datasets >=4.4.0
     - pytest-asyncio
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ build:
     - /usr/lib/libresolv.9.dylib  # [osx]
     - /usr/lib64/libgcc_s.so.1  # [linux]
   script:
+    - cd bindings/python
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-11327) 
- [Upstream repository](https://github.com/huggingface/tokenizers/tree/v0.22.2)

### Explanation of changes:

- Use cxx_compiler_version 11.2.0 for compatibility with rust on linux platforms
- Use github source url because v0.22.2 is not released on PyPI yet
- Clean up the recipe

### Notes:

- 