### PR TITLE
tokenizers 0.21.4

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes
+  

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,2 @@
-rust_compiler_version:
-  - 1.82.0
+#rust_compiler_version:
+#  - 1.82.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tokenizers" %}
-{% set version = "0.21.0" %}
+{% set version = "0.21.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ee0894bf311b75b0c03079f33859ae4b2334d675d4e93f5a4132e1eae2834fe4
+  sha256: fa23f85fbc9a02ec5c6978da172cdcbac23498c3ca9f3645c5c68740ac007880
   patches:  # [win]
     - remove-multiprocess-fork.patch  # [win]
 
@@ -57,8 +57,8 @@ test:
     - pip check
     - cd bindings/python
     # tests require multiprocessing with fork, which is not available on Windows.
-    - pytest tests --ignore="tests/documentation" -k "not test_continuing_prefix_trainer_mistmatch"  # [not win]
-    - pytest tests --ignore="tests/documentation" -k "not (test_continuing_prefix_trainer_mistmatch or test_multiprocessing_with_parallelism)" # [win]
+    - pytest tests --ignore="tests/documentation" -k "not test_continuing_prefix_trainer_mismatch"  # [not win]
+    - pytest tests --ignore="tests/documentation" -k "not (test_continuing_prefix_trainer_mismatch or test_multiprocessing_with_parallelism)" # [win]
   requires:
     - pip
     - pytest


### PR DESCRIPTION
tokenizers 0.21.4

**Destination channel:** defaults

### Links

- [PKG-12324](https://anaconda.atlassian.net/browse/PKG-12324)
- Upstream repo: https://github.com/huggingface/tokenizers
- Upstream release. notes: https://github.com/huggingface/tokenizers/releases
- Conda-forge repo: https://github.com/conda-forge/tokenizers-feedstock
  - ...

### Explanation of changes:

- vLLM needs a tokenizers version >= 0.21.1 and < 0.22.0


[PKG-12324]: https://anaconda.atlassian.net/browse/PKG-12324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ